### PR TITLE
Refactored LoginSuccessResponse to LoginResponse, added LoginStatus

### DIFF
--- a/network/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleNetwork/responses/LoginResponse.java
+++ b/network/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleNetwork/responses/LoginResponse.java
@@ -1,10 +1,14 @@
 package edu.colostate.cs.cs414.chesshireCoders.jungleNetwork.responses;
 
-public class LoginSuccessResponse {
+import edu.colostate.cs.cs414.chesshireCoders.jungleNetwork.types.LoginStatus;
+
+public class LoginResponse {
+
+    LoginStatus loginStatus;
     String sessionToken;
     long expiresOn;         // Expressed as milliseconds since Epoch
 
-    public LoginSuccessResponse(String sessionToken, long expiresOn) {
+    public LoginResponse(String sessionToken, long expiresOn) {
         this.sessionToken = sessionToken;
         this.expiresOn = expiresOn;
     }

--- a/network/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleNetwork/responses/Responses.java
+++ b/network/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleNetwork/responses/Responses.java
@@ -12,7 +12,7 @@ public class Responses {
         kryo.register(GetPlayerResponse.class);
         kryo.register(GetUserGameHistoryResponse.class);
         kryo.register(GetInvitationResponse.class);
-        kryo.register(LoginSuccessResponse.class);
+        kryo.register(LoginResponse.class);
         kryo.register(ErrorResponse.class);
     }
 }

--- a/network/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleNetwork/types/ErrorType.java
+++ b/network/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleNetwork/types/ErrorType.java
@@ -1,10 +1,8 @@
 package edu.colostate.cs.cs414.chesshireCoders.jungleNetwork.types;
 
 public enum ErrorType {
-    SERVER_ERROR,
-    CLIENT_ERROR,
-    UNAUTHORIZED,
-    BAD_LOGIN,
-    BAD_REGISTRATION,
+    SERVER_ERROR, // something broke on the server
+    CLIENT_ERROR, // the client did something wrong
+    UNAUTHORIZED, // the client requested something it's not allowed to access.
     UNKNOWN
 }

--- a/network/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleNetwork/types/LoginStatus.java
+++ b/network/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleNetwork/types/LoginStatus.java
@@ -1,0 +1,8 @@
+package edu.colostate.cs.cs414.chesshireCoders.jungleNetwork.types;
+
+public enum LoginStatus {
+    FAILURE_BAD_CREDENTIALS,
+    FAILURE_NO_USER,
+    FAILURE_ACCOUNT_LOCKED,
+    SUCCESS
+}


### PR DESCRIPTION
This refactors `LoginSuccessResponse` to just `LoginResponse`, and adds a `LoginStatus` enumeration to better communicate the success or failure of a login attempt.