### PR TITLE
Fix for the winner not displaying on losing screen.

### DIFF
--- a/client/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleClient/app/GameBoardController.java
+++ b/client/src/main/java/edu/colostate/cs/cs414/chesshireCoders/jungleClient/app/GameBoardController.java
@@ -195,6 +195,10 @@ public class GameBoardController implements Initializable {
 		}
 		
 		imageViews.add(pieceImage);
+		
+		if (game.getWinner() != null) {
+			showGameEnding(game.getWinner());
+		}
 	}
 	
 	private String getImageForPiece(GamePiece piece) {


### PR DESCRIPTION
After reading through the code it became apparent that the logic of checking and updating the pieces did not require a move to be made, since no move was made showGameEnding was never called. I added the same check from movePiece to the end of placePieceAt.

Closes issue #276 